### PR TITLE
Improved syntax highlighting for cpp macros

### DIFF
--- a/plugins/language_cpp.lua
+++ b/plugins/language_cpp.lua
@@ -12,7 +12,7 @@ syntax.add {
   patterns = {
     { pattern = "//.-\n",               type = "comment"  },
     { pattern = { "/%*", "%*/" },       type = "comment"  },
-    { pattern = { "#", "[^\\]\n" },     type = "comment"  },
+    { pattern = "#%w+",                 type = "keyword"  },
     { pattern = { '"', '"', '\\' },     type = "string"   },
     { pattern = { "'", "'", '\\' },     type = "string"   },
     { pattern = "-?0x%x+",              type = "number"   },


### PR DESCRIPTION
A friend of mine suggested me this editor and did some changes to the `language_cpp` plugin for a better syntax highlighting. In addition I decided to remove the original line that makes any `#` prefixed string as comment, which is something unexpected for this language, better no highlighting at all IMO. Here the result on the `vscode-dark` theme.

![langcpp](https://user-images.githubusercontent.com/1171962/117935977-9a021180-b304-11eb-95a2-b7dfa8f1533e.png)
![langcpp-new](https://user-images.githubusercontent.com/1171962/117935980-9a9aa800-b304-11eb-8f74-c00af6c78e00.png)
