### PR TITLE
lfautoinsert: add js/css multiline /* comments */

### DIFF
--- a/plugins/lfautoinsert.lua
+++ b/plugins/lfautoinsert.lua
@@ -19,6 +19,7 @@ config.lfautoinsert_map = {
   ["%f[%w]repeat%s*\n"] = "until",
   ["%f[%w]function.*%)%s*\n"] = "end",
   ["^%s*<([^/][^%s>]*)[^>]*>%s*\n"] = "</$TEXT>",
+  ["/%*"] = "*/",
 }
 
 


### PR DESCRIPTION
this pull request creates support for js/css multiline comments to be automatically closed
```javascript
/*
this is a multiline comment
*/
```