### PR TITLE
[language_php] overall improvements.

### DIFF
--- a/plugins/language_php.lua
+++ b/plugins/language_php.lua
@@ -1,100 +1,70 @@
 -- lite-xl 1.16
+--[[
+    language_php.lua
+    provides php syntax support allowing mixed html, css and js
+    version: 20210513_144200
+
+    Depends on plugin language_phps.lua version >= 20210512_181200
+--]]
 local syntax = require "core.syntax"
 
 syntax.add {
   files = { "%.php$", "%.phtml" },
-  headers = "^<%?php",
-  comment = "//",
   patterns = {
-    { pattern = "//.-\n",                 type = "comment"  },
-    { pattern = "#.-\n",                  type = "comment"  },
-    { pattern = { "/%*", "%*/" },         type = "comment"  },
-    -- I dont know why the '//' are needed but I leave it here for now
-    { pattern = { '"', '"', '\\' },       type = "string"   },
-    { pattern = { "'", "'", '\\' },       type = "string"   },
-    { pattern = "%\\x[%da-fA-F]+",        type = "number"   },
-    { pattern = "-?%d+[%d%.eE]*",         type = "number"   },
-    { pattern = "-?%.?%d+",               type = "number"   },
-    { pattern = "[%.%+%-=/%*%^%%<>!~|&]", type = "operator" },
-    { pattern = "[%a_][%w_]*%f[(]",       type = "function" },
-    { pattern = "[%a_][%w_]*",            type = "symbol"   },
-    -- To indicate variables.
-    { pattern = "%$",          type = "operator" },
+    {
+      pattern = {
+        "<%?php%s+",
+        "%?>"
+      },
+      syntax = ".phps",
+      type = "keyword2"
+    },
+    {
+      pattern = {
+        "<%?=?",
+        "%?>"
+      },
+      syntax = ".phps",
+      type = "keyword2"
+    },
+    {
+      pattern = {
+        "<%s*[sS][cC][rR][iI][pP][tT]%s+[tT][yY][pP][eE]%s*=%s*" ..
+          "['\"]%a+/[jJ][aA][vV][aA][sS][cC][rR][iI][pP][tT]['\"]%s*>",
+        "<%s*/[sS][cC][rR][iI][pP][tT]>"
+      },
+      syntax = ".js",
+      type = "function"
+    },
+    {
+      pattern = {
+        "<%s*[sS][cC][rR][iI][pP][tT]%s*>",
+        "<%s*/%s*[sS][cC][rR][iI][pP][tT]>"
+      },
+      syntax = ".js",
+      type = "function"
+    },
+    {
+      pattern = {
+        "<%s*[sS][tT][yY][lL][eE][^>]*>",
+        "<%s*/%s*[sS][tT][yY][lL][eE]%s*>"
+      },
+      syntax = ".css",
+      type = "function"
+    },
+    { pattern = { "<!%-%-", "%-%->" },     type = "comment"  },
+    { pattern = { '%f[^>][^<]', '%f[<]' }, type = "normal"   },
+    { pattern = { '"', '"', '\\' },        type = "string"   },
+    { pattern = { "'", "'", '\\' },        type = "string"   },
+    { pattern = "0x[%da-fA-F]+",           type = "number"   },
+    { pattern = "-?%d+[%d%.]*f?",          type = "number"   },
+    { pattern = "-?%.?%d+f?",              type = "number"   },
+    { pattern = "%f[^<]![%a_][%w_]*",      type = "keyword2" },
+    { pattern = "%f[^<][%a_][%w_]*",       type = "function" },
+    { pattern = "%f[^<]/[%a_][%w_]*",      type = "function" },
+    { pattern = "[%a_][%w_]*",             type = "keyword"  },
+    { pattern = "[/<>=]",                  type = "operator" },
   },
-  symbols = {
-    ["return"] = "keyword",
-    ["if"] = "keyword",
-    ["else"] = "keyword",
-    ["elseif"] = "keyword",
-    ["endif"] = "keyword",
-    ["declare"] = "keyword",
-    ["enddeclare"] = "keyword",
-    ["switch"] = "keyword",
-    ["endswitch"] = "keyword",
-    ["as"] = "keyword",
-    ["do"] = "keyword",
-    ["for"] = "keyword",
-    ["endfor"] = "keyword",
-    ["foreach"] = "keyword",
-    ["endforeach"] = "keyword",
-    ["while"] = "keyword",
-    ["endwhile"] = "keyword",
-    ["switch"] = "keyword",
-    ["case"] = "keyword",
-    ["continue"] = "keyword",
-    ["default"] = "keyword",
-    ["break"] = "keyword",
-    ["exit"] = "keyword",
-    ["goto"] = "keyword",
-
-    ["catch"] = "keyword",
-    ["throw"] = "keyword",
-    ["try"] = "keyword",
-    ["finally"] = "keyword",
-
-    ["class"] = "keyword",
-    ["trait"] = "keyword",
-    ["interface"] = "keyword",
-    ["public"] = "keyword",
-    ["static"] = "keyword",
-    ["protected"] = "keyword",
-    ["private"] = "keyword",
-    ["abstract"] = "keyword",
-    ["final"] = "keyword",
-
-    ["function"] = "keyword2",
-    ["global"] = "keyword2",
-    ["var"] = "keyword2",
-    ["const"] = "keyword2",
-    ["bool"] = "keyword2",
-    ["boolean"] = "keyword2",
-    ["int"] = "keyword2",
-    ["integer"] = "keyword2",
-    ["real"] = "keyword2",
-    ["double"] = "keyword2",
-    ["float"] = "keyword2",
-    ["string"] = "keyword2",
-    ["array"] = "keyword2",
-    ["object"] = "keyword2",
-    ["callable"] = "keyword2",
-    ["iterable"] = "keyword2",
-
-    ["namespace"] = "keyword2",
-    ["extends"] = "keyword2",
-    ["implements"] = "keyword2",
-    ["instanceof"] = "keyword2",
-    ["require"] = "keyword2",
-    ["require_once"] = "keyword2",
-    ["include"] = "keyword2",
-    ["include_once"] = "keyword2",
-    ["use"] = "keyword2",
-    ["new"] = "keyword2",
-    ["clone"] = "keyword2",
-
-    ["true"] = "literal",
-    ["false"] = "literal",
-    ["NULL"] = "literal",
-    ["parent"] = "literal",
-    ["self"] = "literal",
-  },
+  symbols = {},
 }
+

--- a/plugins/language_phps.lua
+++ b/plugins/language_phps.lua
@@ -1,0 +1,140 @@
+-- lite-xl 1.16
+--[[
+    language_phps.lua
+    complement to language_php.lua providing the php syntax support
+    version: 20210512_181200
+--]]
+local syntax = require "core.syntax"
+
+syntax.add {
+  files = { "%.phps$" },
+  headers = "^<%?php",
+  comment = "//",
+  patterns = {
+    -- Attributes
+    { pattern = {"#%[", "%]"},               type = "normal"   },
+    -- Comments
+    { pattern = "//.-\n",                    type = "comment"  },
+    { pattern = "#.-\n",                     type = "comment"  },
+    { pattern = { "/%*", "%*/" },            type = "comment"  },
+    -- The '\\' is for escaping to work on " or '
+    { pattern = { '"', '"', '\\' },          type = "string"   },
+    { pattern = { "'", "'", '\\' },          type = "string"   },
+    { pattern = "0[bB][%d]+",                type = "number"   },
+    { pattern = "0[xX][%da-fA-F]+",          type = "number"   },
+    { pattern = "-?%d[%d_%.eE]*",            type = "number"   },
+    { pattern = "-?%.?%d+",                  type = "number"   },
+    { pattern = "[%.%+%-=/%*%^%%<>!~|&%?:]", type = "operator" },
+     -- Variables
+    { pattern = "%$[%w_]+",                  type = "keyword2" },
+    -- Respect control structures, treat as keyword not function
+    { pattern = "if[%s]*%f[(]",              type = "keyword"  },
+    { pattern = "else[%s]*%f[(]",            type = "keyword"  },
+    { pattern = "elseif[%s]*%f[(]",          type = "keyword"  },
+    { pattern = "for[%s]*%f[(]",             type = "keyword"  },
+    { pattern = "foreach[%s]*%f[(]",         type = "keyword"  },
+    { pattern = "while[%s]*%f[(]",           type = "keyword"  },
+    { pattern = "catch[%s]*%f[(]",           type = "keyword"  },
+    { pattern = "switch[%s]*%f[(]",          type = "keyword"  },
+    { pattern = "match[%s]*%f[(]",           type = "keyword"  },
+    { pattern = "fn[%s]*%f[(]",              type = "keyword"  },
+    -- All functions that aren't control structures
+    { pattern = "[%a_][%w_]*[%s]*%f[(]",     type = "function" },
+    -- Array type hint not added on symbols to also make it work
+    -- as a function call
+    { pattern = "array",                     type = "literal"  },
+    -- Match static or namespace container on sub element access
+    { pattern = "[%a_][%w_]*[%s]*%f[:]",     type = "literal"  },
+    -- Uppercase constants of at least 3 characters in len
+    { pattern = "%u[%u_][%u%d_]+",           type = "number"   },
+    -- Magic constants
+    { pattern = "__[%u]+__",                 type = "number"   },
+    -- Everything else
+    { pattern = "[%a_][%w_]*",               type = "symbol"   },
+  },
+  symbols = {
+    ["return"] = "keyword",
+    ["if"] = "keyword",
+    ["else"] = "keyword",
+    ["elseif"] = "keyword",
+    ["endif"] = "keyword",
+    ["declare"] = "keyword",
+    ["enddeclare"] = "keyword",
+    ["switch"] = "keyword",
+    ["endswitch"] = "keyword",
+    ["as"] = "keyword",
+    ["do"] = "keyword",
+    ["for"] = "keyword",
+    ["endfor"] = "keyword",
+    ["foreach"] = "keyword",
+    ["endforeach"] = "keyword",
+    ["while"] = "keyword",
+    ["endwhile"] = "keyword",
+    ["switch"] = "keyword",
+    ["match"] = "keyword",
+    ["case"] = "keyword",
+    ["continue"] = "keyword",
+    ["default"] = "keyword",
+    ["break"] = "keyword",
+    ["goto"] = "keyword",
+
+    ["try"] = "keyword",
+    ["catch"] = "keyword",
+    ["throw"] = "keyword",
+    ["finally"] = "keyword",
+
+    ["class"] = "keyword",
+    ["trait"] = "keyword",
+    ["interface"] = "keyword",
+    ["public"] = "keyword",
+    ["static"] = "keyword",
+    ["protected"] = "keyword",
+    ["private"] = "keyword",
+    ["abstract"] = "keyword",
+    ["final"] = "keyword",
+    ["$this"] = "literal",
+
+    ["function"] = "keyword",
+    ["fn"] = "keyword",
+    ["global"] = "keyword",
+    ["var"] = "keyword",
+    ["const"] = "keyword",
+
+    ["bool"] = "literal",
+    ["boolean"] = "literal",
+    ["int"] = "literal",
+    ["integer"] = "literal",
+    ["real"] = "literal",
+    ["double"] = "literal",
+    ["float"] = "literal",
+    ["string"] = "literal",
+    ["object"] = "literal",
+    ["callable"] = "literal",
+    ["iterable"] = "literal",
+    ["void"] = "literal",
+    ["parent"] = "literal",
+    ["self"] = "literal",
+    ["mixed"] = "literal",
+
+    ["namespace"] = "keyword",
+    ["extends"] = "keyword",
+    ["implements"] = "keyword",
+    ["instanceof"] = "keyword",
+    ["require"] = "keyword",
+    ["require_once"] = "keyword",
+    ["include"] = "keyword",
+    ["include_once"] = "keyword",
+    ["use"] = "keyword",
+    ["new"] = "keyword",
+    ["clone"] = "keyword",
+
+    ["true"] = "number",
+    ["false"] = "number",
+    ["NULL"] = "number",
+    ["null"] = "number",
+
+    ["print"] = "function",
+    ["echo"] = "function",
+    ["exit"] = "function",
+  },
+}


### PR DESCRIPTION
Worked on improving the PHP language support:

* Use the new mixed syntax color support to allow html, css and js on .php files. 
* Renamed language_php.lua to language_phphtml.lua to better reflect that the file now has html rules (basically language_html but besides css and js also supports &lt;?php ?&gt;, &lt;?= ?&gt; tags with language_phps)
* Introduced language_phps.lua to provide the actual PHP syntax highlighting rules for language_phphtml.lua
* Added some new PHP 8 features like differentiating attributes from comments.
* Allow spaces between functions and parenthesis.
* Colorize static or scope access calls.
* Colorize variables for better readability as other editors do.
* Differentiate array type hinting from array(...) declarations.
* Added support for missing and newer number formats.
* Colorize constants and magic constants.
* Other improvements and changes to color assignments as newer keywords like 'match' and 'fn'.
## Some comparison
Current syntax rules:
![2021-05-13_15:43:13](https://user-images.githubusercontent.com/1702572/118182682-4af0d500-b407-11eb-993a-fa93b4ab5b0d.png)
New syntax improvements:
![2021-05-13_15:44:11](https://user-images.githubusercontent.com/1702572/118182825-6eb41b00-b407-11eb-98f5-0b32ea527b5d.png)

## Things that could be improved

Currently with this method one is able to write HTML inside php files and insert &lt;?php ?&gt; inside the html tags with nice php syntax coloring. The same is not possible if wanting to insert &lt;?php ?&gt; inside 'script' or 'style' tags as can be seen on the following capture:
![2021-05-13_16:59:37](https://user-images.githubusercontent.com/1702572/118187314-c3a66000-b40c-11eb-8b6f-fda4cc6fa823.png)

Anyways, this pull request makes things a lot better now with the new mixed syntax support.


