### PR TITLE
Quick Fix: changed target of Plugin eofnewline

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Plugin | Description
 *[`discord-presence`](https://github.com/vincens2005/lite-xl-discord)* * | Adds the current workspace and file to your Discord Rich Presence
 [`dragdropselected`](plugins/dragdropselected.lua?raw=1) | Provides basic drag and drop of selected text (in same document)
 ~~*[`drawwhitespace`](plugins/drawwhitespace.lua?raw=1)*~~ | Integrated with lite-xl reducing CPU usage ~~Draws tabs and spaces *([screenshot](https://user-images.githubusercontent.com/3920290/80573013-22ae5800-89f7-11ea-9895-6362a1c0abc7.png))*~~
-[`eofnewline`](https://github.com/bokunodev/lite_modules/blob/master/plugins/eofnewline.lua?raw=1) | Make sure the file ends with one blank line.
+[`eofnewline`](https://github.com/bokunodev/lite_modules/blob/master/plugins/eofnewline-xl.lua?raw=1) | Make sure the file ends with one blank line.
 [`eval`](plugins/eval.lua?raw=1) | Replaces selected Lua code with its evaluated result
 [`exec`](plugins/exec.lua?raw=1) | Runs selected text through shell command and replaces with result
 [`fallbackfonts`](https://github.com/takase1121/lite-fallback-fonts)* | Adds support for fallback fonts *([gif](https://raw.githubusercontent.com/takase1121/lite-fallback-fonts/master/assets/Iw18fI57J0.gif))*


### PR DESCRIPTION
The Plugin "eofnewline" was missing the required `-- lite-xl 1.16` at the start of the file.
I duplicated the original file and added the line. The new file is called `eofnewline-xl.lua`.
A PR was submitted and accepted from the original author.
This commit simply changes the target from `eofnewline.lua` to `eofnewline-xl.lua`.